### PR TITLE
Resolved error in installation due to setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,11 @@
 language: python
 
-python:
-    - 2.6
-    - 2.7
-    - 3.2
-    - 3.3
-    - 3.4
-    # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
     global:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.8
-        - ASTROPY_VERSION=stable
-        - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
+        
         - PIP_INSTALL='pip install'
     matrix:
         - SETUP_CMD='egg_info'
@@ -26,39 +17,6 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='test --coverage'
 
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
-        - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
-
-        # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
-        - python: 3.3
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
-
-        # Try all python versions with the latest numpy
-        - python: 2.6
-          env: SETUP_CMD='test'
-        - python: 2.7
-          env: SETUP_CMD='test'
-        - python: 3.2
-          env: SETUP_CMD='test'
-        - python: 3.3
-          env: SETUP_CMD='test'
-        - python: 3.4
-          env: SETUP_CMD='test'
-
-        # Try older numpy versions
-        - python: 3.2
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.5 SETUP_CMD='test'
-
 before_install:
 
     # Use utf8 encoding. Should be default, but this is insurance against
@@ -67,26 +25,18 @@ before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
+    - export PATH=/home/travis/miniconda2/bin:$PATH
     - conda update --yes conda
-
-    # DOCUMENTATION DEPENDENCIES
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
+    
+    # UPDATE APT-GET LISTINGS
+    - sudo apt-get update
 
 install:
 
     # CONDA
-    - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
-    - source activate test
-
-    # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
-
-    # ASTROPY
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
-
+    - conda env create -n starkit --file ./starkit_env27.yml
+    - source activate starkit
+    
     # OPTIONAL DEPENDENCIES
     # Here you can add any dependencies your package may have. You can use
     # conda for packages available through conda, or pip for any other
@@ -94,12 +44,6 @@ install:
     # install since this ensures Numpy does not get automatically upgraded.
     # - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
     # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
-
-    # DOCUMENTATION DEPENDENCIES
-    # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
-    # this matplotlib will *not* work with py 3.x, but our sphinx build is
-    # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi

--- a/starkit_env27.yml
+++ b/starkit_env27.yml
@@ -30,6 +30,7 @@ dependencies:
 - pytest-cov=2.2.1
 
 - pip:
+  - setuptools==36.2.0
   - sphinx_bootstrap_theme
   - coveralls
   - numpydoc


### PR DESCRIPTION
For resolving the following error in installation (which is similar to starkit/starkit#30):
```bash
$ python setup.py install
Initializing astropy_helpers submodule with: `git submodule update --init -- astropy_helpers`
/home/jpolygon/wsynphot-test/wsynphot/astropy_helpers/astropy_helpers/setup_helpers.py:102: AstropyDeprecationWarning: Direct use of the adjust_compiler function in setup.py is deprecated and can be removed from your setup.py.  This functionality is now incorporated directly into the build_ext command.
  'command.', AstropyDeprecationWarning)
Traceback (most recent call last):
  File "setup.py", line 65, in <module>
    get_debug_option(PACKAGENAME))
  File "/home/jpolygon/wsynphot-test/wsynphot/astropy_helpers/astropy_helpers/setup_helpers.py", line 125, in get_debug_option
    if any(cmd in dist.commands for cmd in ['build', 'build_ext']):
  File "/home/jpolygon/wsynphot-test/wsynphot/astropy_helpers/astropy_helpers/setup_helpers.py", line 125, in <genexpr>
    if any(cmd in dist.commands for cmd in ['build', 'build_ext']):
AttributeError: Distribution instance has no attribute 'commands'
```
I have downgraded the setuptools in similar way it was fixed at [here](https://github.com/starkit/starkit/commit/e4e7f2063e143f85bac3b2ffa916c5fa466bd9de#diff-274e053ea36134010643108a0f89b2c9).

Doing these changes `wsynphot` gets installed in 1st attempt itself (without throwing any error).