### PR TITLE
Updated both starkit_env27.yml and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,63 +1,19 @@
 language: python
 
-python:
-    - 2.6
-    - 2.7
-    - 3.2
-    - 3.3
-    - 3.4
-    # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
     global:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.8
-        - ASTROPY_VERSION=stable
-        - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
     matrix:
         - SETUP_CMD='egg_info'
 
 matrix:
     include:
-
-        # Do a coverage test in Python 2. 
+        # Do a coverage test in Python 2.
         - python: 2.7
           env: SETUP_CMD='test --coverage'
-
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
-        - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
-
-        # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
-        - python: 3.3
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
-
-        # Try all python versions with the latest numpy
-        - python: 2.6
-          env: SETUP_CMD='test'
-        - python: 2.7
-          env: SETUP_CMD='test'
-        - python: 3.2
-          env: SETUP_CMD='test'
-        - python: 3.3
-          env: SETUP_CMD='test'
-        - python: 3.4
-          env: SETUP_CMD='test'
-
-        # Try older numpy versions
-        - python: 3.2
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.5 SETUP_CMD='test'
 
 before_install:
 
@@ -67,25 +23,17 @@ before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
+    - export PATH=/home/travis/miniconda2/bin:$PATH
     - conda update --yes conda
 
-    # DOCUMENTATION DEPENDENCIES
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
+    # UPDATE APT-GET LISTINGS
+    - sudo apt-get update
 
 install:
 
     # CONDA
-    - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
-    - source activate test
-
-    # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
-
-    # ASTROPY
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
+    - conda env create -n starkit --file ./starkit_env27.yml
+    - source activate starkit
 
     # OPTIONAL DEPENDENCIES
     # Here you can add any dependencies your package may have. You can use
@@ -94,12 +42,6 @@ install:
     # install since this ensures Numpy does not get automatically upgraded.
     # - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
     # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
-
-    # DOCUMENTATION DEPENDENCIES
-    # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
-    # this matplotlib will *not* work with py 3.x, but our sphinx build is
-    # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
@@ -111,4 +53,4 @@ after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi
+# - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi

--- a/starkit_env27.yml
+++ b/starkit_env27.yml
@@ -4,24 +4,22 @@ channels:
     - conda-forge
 
 dependencies:
-- python=2.7.15
-- numpy=1.12
-- scipy=1.0
-- pandas
-- pytables
+- python=2.7
+- numpy=1
 - h5py=2.6
-- matplotlib
-- astropy=2
+- matplotlib=2
+- astropy=1.1.2
 - numexpr=2.6
 - pytest=3.0
 - pyyaml=3.12
 - tqdm=4
 - jupyter
+- notebook
+- scipy
+- pandas
+- pytables
 
 # RTD requirements
-- nbformat
-- nbconvert
-- sphinx
 
 #Coverage requirements
 - coverage=3.7.1
@@ -30,8 +28,14 @@ dependencies:
 - pytest-cov=2.2.1
 
 - pip:
+  - setuptools==36.2.0
   - sphinx_bootstrap_theme
+  - sphinxcontrib-bibtex
+  - sphinxcontrib-tikz
   - coveralls
+  - sphinx==1.5.3
+  - nbconvert
   - numpydoc
   - docutils
-  - nbsphinx
+  - nbformat
+- nbsphinx

--- a/starkit_env27.yml
+++ b/starkit_env27.yml
@@ -38,4 +38,4 @@ dependencies:
   - numpydoc
   - docutils
   - nbformat
-- nbsphinx
+  - nbsphinx


### PR DESCRIPTION
As per [this](https://github.com/starkit/wsynphot/pull/6#issuecomment-468025508), both the `wsynphot/starkit_env27.yml` and `wsynphot/.travis.yml` are changed to similar as `starkit/starkit_env27.yml` and `starkit/.travis.yml` respectively so that:
1. [This error](https://github.com/starkit/wsynphot/pull/6#issue-256831612) in installation of wsynphot (requiring downgradation of setuptools) can be solved
2. Build can be passed by Travis CI