### PR TITLE
Fixed the error in building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,6 @@ version = package.__version__.split('-', 1)[0]
 release = package.__version__
 extensions += [
     'nbsphinx',
-    'sphinx.ext.mathjax',
     ]
 
 

--- a/starkit_env27.yml
+++ b/starkit_env27.yml
@@ -20,7 +20,7 @@ dependencies:
 
 # RTD requirements
 - nbformat
-- nbsphinx
+- nbsphinx==0.3.5
 - nbconvert
 - sphinx==1.5.6
 

--- a/starkit_env27.yml
+++ b/starkit_env27.yml
@@ -20,6 +20,7 @@ dependencies:
 
 # RTD requirements
 - nbformat
+- nbsphinx
 - nbconvert
 - sphinx
 
@@ -34,4 +35,3 @@ dependencies:
   - coveralls
   - numpydoc
   - docutils
-  - nbsphinx

--- a/starkit_env27.yml
+++ b/starkit_env27.yml
@@ -20,7 +20,6 @@ dependencies:
 
 # RTD requirements
 - nbformat
-- nbsphinx==0.3.5
 - nbconvert
 - sphinx==1.5.6
 
@@ -35,3 +34,5 @@ dependencies:
   - coveralls
   - numpydoc
   - docutils
+  - nbsphinx==0.3.5
+  

--- a/starkit_env27.yml
+++ b/starkit_env27.yml
@@ -22,7 +22,7 @@ dependencies:
 - nbformat
 - nbsphinx
 - nbconvert
-- sphinx
+- sphinx==1.5.6
 
 #Coverage requirements
 - coverage=3.7.1


### PR DESCRIPTION
The error was due to these problems:
1. `numpydoc` is compatible with older version of `sphinx` -> Restricted the version of sphinx to 1.5
2. Importing `nbsphinx` (latest version) creates problem due to some missing `sphinx/transforms` files -> As per [this issue](https://github.com/spatialaudio/nbsphinx/issues/263), restricting the version of `nbsphinx` to 0.3.5 solve the problem
3. `sphinx.ext.mathjax` was being imported twice (See commit details)