### PR TITLE
Disable use_2to3 flag to make `setup.py develop` work fine in python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,6 @@ setup(name=PACKAGENAME,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
+      use_2to3=False,
       **package_info
 )


### PR DESCRIPTION
Whenever I use `setup.py develop`, I need to run `setup.py build` each time I make a change - which is not why we use development mode instead it is for saving us from this hassle. The reason I found is `.egg-link` for wsynphot in `site-packages` links to `build` directory instead of actual source code directory. 

I further investigated why it is choosing build directory and found this in [setuptools docs](https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode):
> If you have enabled the use_2to3 flag, then of course the .egg-link will not link directly to your source code when run under Python 3, since that source code would be made for Python 2 and not work under Python 3. Instead the setup.py develop will build Python 3 code under the build directory, and link there. This means that after doing code changes you will have to run setup.py build before these changes are picked up by your Python 3 installation.

So I disabled `use_2to3` flag as we are no longer supporting python2.7 and `setup.py develop` works fine as needed in python3 environment.