### PR TITLE
Improved tests for get_filter_data & cache_filters module

### DIFF
--- a/wsynphot/io/tests/test_cache_filters.py
+++ b/wsynphot/io/tests/test_cache_filters.py
@@ -1,65 +1,120 @@
 import pytest
 import os, re
-import pandas.testing as pdt
 
 import wsynphot
+from wsynphot.io.get_filter_data import data_from_svo
 from wsynphot.io import cache_filters as cf
 
 DATA_PATH = os.path.join(wsynphot.__path__[0], 'io', 'tests', 'data')
-CACHE_DIR = os.path.join(DATA_PATH, 'filters', 'SVO')
+CACHE_READING_DIR = os.path.join(DATA_PATH, 'filters', 'SVO')  # read test data
+TEST_LAMBDA = 12000
 
-@pytest.fixture
-def sample_table():
-    from astropy.table import Table
-    table = Table()
-    table['a'] = [1.56, 2.34, 3.78, 4.71]
-    table['b'] = [0.1, 0.2, 0.4, 0.5]
-    return table
+# Temporary dir for storing the cache data written by functions while testing
+@pytest.fixture(scope='module')
+def cache_writing_dir(tmpdir_factory):
+    return str(tmpdir_factory.mktemp('cache_data'))
 
-def test_cache_as_votable(sample_table):
-    sample_votable_path = os.path.join(DATA_PATH, 'sample_table.vot')
-    cf.cache_as_votable(sample_table, sample_votable_path)
-    # Convert back cached votable to a dataframe "data" and compare it 
-    data = cf.df_from_votable(sample_votable_path)
-    pdt.assert_frame_equal(sample_table.to_pandas(), data)
 
-@pytest.fixture
-def sample_filter_ids():
-    filter_ids_list = ['Keck/NIRC2.Kp', 'Keck/LWS/SiC']
-    return filter_ids_list
+# ---------------- Tests for cache writing functions -------------------------
 
-def test_iterative_download_transmission_data(sample_filter_ids):
-    cf.iterative_download_transmission_data(sample_filter_ids, CACHE_DIR)
-    for filter_id in sample_filter_ids:
+def test_download_filter_data(monkeypatch, cache_writing_dir):
+    '''download_filter_data() calls get_filter_index() which fetches complete 
+    filter index (~5K filters), instead of it use a mock function to fetch 
+    only a short filter list (<10 filters)'''
+    def mock_get_filter_index():
+        query = {'WavelengthEff_min': TEST_LAMBDA,
+                'WavelengthEff_max': TEST_LAMBDA+100}
+        return data_from_svo(query, 'No filters in specified wavelength range')
+
+    # Inject mock_get_filter_index in place of get_filter_index
+    monkeypatch.setattr(cf, 'get_filter_index', mock_get_filter_index)
+    cf.download_filter_data(cache_writing_dir)
+
+    # Test whether cached index votable is converible to dataframe
+    index_path = os.path.join(cache_writing_dir, 'index.vot')
+    assert os.path.exists(index_path)
+    index = cf.df_from_votable(index_path)
+    assert not index.empty
+
+    # Test whether filter votables got cached in appropriate directories
+    for filter_id in index['filterID']:
         facility, instrument, filter_name = re.split('/|\.', filter_id)
-        # Check whether filter votable get stored in appropriate directory
-        assert os.path.exists(os.path.join(CACHE_DIR, facility, instrument,
-            '{0}.vot'.format(filter_name)))
+        assert os.path.exists(os.path.join(cache_writing_dir, facility, 
+            instrument, '{0}.vot'.format(filter_name)))
+
+
+
+def test_update_filter_data(monkeypatch, cache_writing_dir):
+    # Read old index (i.e. cached by download function) before updating it
+    index = cf.df_from_votable(os.path.join(cache_writing_dir, 'index.vot'))
+
+    '''update_filter_data() calls get_filter_index() to fetch new filter index, 
+    mock it to fetch only a short filter list instead of complete index'''
+    def mock_get_filter_index():
+
+        '''Choose wavelength range for the new index to be overlapping with 
+        the index present on disk, so that we can get filters to remove as
+        well as to add. Ranges used are:
+        old index:      x ---------- x+100
+        new index:        x+50 ---------- x+150          (x = TEST_LAMBDA)
+        '''
+        query = {'WavelengthEff_min': TEST_LAMBDA+50,
+                'WavelengthEff_max': TEST_LAMBDA+150}
+        return data_from_svo(query, 'No filters in specified wavelength range')
+
+
+    # Inject mock_get_filter_index in place of get_filter_index
+    monkeypatch.setattr(cf, 'get_filter_index', mock_get_filter_index)
+    cf.update_filter_data(cache_writing_dir)
+
+    # Find the outdated filters & test whether their votables got removed
+    removed_filters = index[index['WavelengthEff'] < TEST_LAMBDA+50]['filterID']
+    for filter_id in removed_filters:
+        facility, instrument, filter_name = re.split('/|\.', filter_id)
+        assert not os.path.exists(os.path.join(cache_writing_dir, facility, 
+            instrument, '{0}.vot'.format(filter_name))) 
+
+    # Read the updated index (i.e. cached by update function)
+    index = cf.df_from_votable(os.path.join(cache_writing_dir, 'index.vot'))
+    
+    # Find the new filters & test whether their votables got cached
+    added_filters = index[index['WavelengthEff'] > TEST_LAMBDA+100]['filterID']
+    for filter_id in added_filters:
+        facility, instrument, filter_name = re.split('/|\.', filter_id)
+        assert os.path.exists(os.path.join(cache_writing_dir, facility, 
+            instrument, '{0}.vot'.format(filter_name)))
+
+
+# ------------------ Tests for cache reading functions -----------------------
 
 def test_load_filter_index():
-    data = cf.load_filter_index(CACHE_DIR)
+    data = cf.load_filter_index(CACHE_READING_DIR)
     assert data.empty == False
     assert 'filterID' in data.columns
+
 
 def test_IOError_in_load_filter_index():
     # When no filter index found in passed cache directory
     pytest.raises(IOError, cf.load_filter_index, DATA_PATH)
 
+
 @pytest.mark.parametrize(('test_filter_id'), 
                         ['HST/NICMOS1.F113N', 'HST/ACS_HRC.F250W'])
 def test_load_transmission_data(test_filter_id):
-    data = cf.load_transmission_data(test_filter_id, CACHE_DIR)
+    data = cf.load_transmission_data(test_filter_id, CACHE_READING_DIR)
     assert data.empty == False
     assert (data['Wavelength'] > 0).all() == True
     assert ((data['Transmission'] >= 0) &
         (data['Transmission'] <= 1)).all() == True
 
+
 def test_IOError_in_load_transmission_data():
     # 'Spitzer/IRAC.I2' exists in filter index but not in cache
     pytest.raises(IOError, cf.load_transmission_data, 'Spitzer/IRAC.I2', 
-        CACHE_DIR)
+        CACHE_READING_DIR)
+
 
 def test_ValueError_in_load_transmission_data():
     # 'no/such.filter' is a dummy filter id which doesn't exist
     pytest.raises(ValueError, cf.load_transmission_data, 'no/such.filter', 
-        CACHE_DIR)
+CACHE_READING_DIR)

--- a/wsynphot/io/tests/test_get_filter_data.py
+++ b/wsynphot/io/tests/test_get_filter_data.py
@@ -3,7 +3,7 @@ import pytest
 from wsynphot.io import get_filter_data as gfd
 
 def test_get_filter_index():
-    table = gfd.get_filter_index()
+    table = gfd.get_filter_index(12000, 12500)  # index in a limited length
     # Check if column for Filter ID (named 'filterID') exists in table
     assert 'filterID' in table.to_table().colnames
 
@@ -20,3 +20,10 @@ def test_get_filter_list(test_facility, test_instrument):
     table = gfd.get_filter_list(test_facility, test_instrument)
     # Check if column for Filter ID (named 'filterID') exists in table
     assert 'filterID' in table.to_table().colnames
+
+'''data_from_svo() is called by above functions internally and is expected to 
+pass, thus failing case is tested by the following test'''
+def test_ValueError_in_data_from_svo():
+    invalid_query = {'Invalid_param': 0}
+    pytest.raises(ValueError, gfd.data_from_svo, invalid_query, 
+        'Invalid search parameters')


### PR DESCRIPTION
This PR is to improve the efficiency of tests I created for get_filter_data & cache_filters module (by increasing code coverage & reducing execution time). Following are the changes in their corresponding test modules:
- `test_get_filter_data`:
  - `get_filter_index()` fetches the complete filter index & takes > 30s, so I limited the index length by passing Wavelength_Eff parameters to it, hence time reduced to ~7s only
  - Failing case for `data_from_svo()` is not covered, so I added a test for it

- `test_cache_filters`:
Cache reading functions (`load_filter_index` & `load_transmission_data`) are being covered completely but not the cache writing functions (`download_filter_data` & `update_filter_data`) since they have huge data dependencies. They are internally calling get_filter_index() (without parameters) to get entire dataset and hence it didn't seem feasible to test them directly so we were testing only the helper functions they are calling. 
Now in this PR I've resolved this limitation by using `pytest monkeypatch` fixture to mock that huge dependency to a very shorter one (by using wavelength range parameters). Therefore we can now actually test the main download & update functions, and their helpers functions will get implicitly tested. This has also increased coverage for `cache_filters` module significantly (from ~67% to 95%)! 
So in this PR, you'll find some major changes in the tests for cache writing functions which has even resulted several other benefits:
  - Reduced dependency on SVO by eliminating the direct specification of filter ids list which are prone to change. Instead of it, now we are using wavelength range to iterate over filters.
  - Isolated the directory from which cache is read and into which cache is written, which should be logically different to prevent changing the saved test data.

Also I've included enough comments to explain the code I added, to ensure that the tests remain maintainable.