### PR TITLE
Made data input more flexible and solved bug in calculations

### DIFF
--- a/wsynphot/base.py
+++ b/wsynphot/base.py
@@ -1,11 +1,11 @@
 # defining the base filter curve classes
 
 import os
-
+import logging
 from scipy import interpolate
 from wsynphot.spectrum1d import SKSpectrum1D as Spectrum1D
 import pandas as pd
-from wsynphot.io.cache_filters import DetectorType, load_filter_index, load_transmission_data
+from wsynphot.io.cache_filters import DetectorType, load_local_filters_index, load_transmission_data
 
 
 
@@ -14,7 +14,7 @@ from astropy import units as u, constants as const
 from astropy import utils
 import numpy as np
 from wsynphot.calibration import get_vega_calibration_spectrum
-
+logger = logging.getLogger(__name__)
 
 def calculate_filter_flux_density(spectrum, filter):
     """
@@ -63,9 +63,12 @@ def calculate_ab_magnitude(spectrum, filter):
 
 def list_filters():
     """
-    List available filter sets along with their properties
+    List available filters
     """
-    return load_filter_index()
+    logger.info("Following filters present in your cache directory are "
+                "available to use (to see all filters you can download from "
+                "SVO, use wsynphot.io.cache_filters.load_svo_filters_index()):")
+    return pd.Series(load_local_filters_index(), name="Filter ID")
 
 
 class BaseFilterCurve(object):

--- a/wsynphot/base.py
+++ b/wsynphot/base.py
@@ -5,7 +5,7 @@ import os
 from scipy import interpolate
 from wsynphot.spectrum1d import SKSpectrum1D as Spectrum1D
 import pandas as pd
-from wsynphot.io.cache_filters import load_filter_index, load_transmission_data
+from wsynphot.io.cache_filters import DetectorType, load_filter_index, load_transmission_data
 
 
 
@@ -34,8 +34,13 @@ def calculate_filter_flux_density(spectrum, filter):
     """
 
     filtered_spectrum = filter * spectrum
-    filter_flux_density = np.trapz(filtered_spectrum.flux * filtered_spectrum.wavelength,
+    if filter.detector_type == DetectorType.PHOTON_COUNTER:
+        filter_flux_density = np.trapz(filtered_spectrum.flux * filtered_spectrum.wavelength,
                     filtered_spectrum.wavelength)
+    else:  # DetectorType.ENERGY_COUNTER
+        filter_flux_density = np.trapz(filtered_spectrum.flux,
+                                       filtered_spectrum.wavelength)
+
     return filter_flux_density
 
 
@@ -100,23 +105,24 @@ class BaseFilterCurve(object):
             return list_filters()
 
         else:
-            filter = load_transmission_data(filter_id)
+            transmission_data, detector_type = load_transmission_data(
+                filter_id)
             
             wavelength_unit = 'angstrom'
 
-            wavelength = filter['Wavelength'].values * u.Unit(wavelength_unit)
+            wavelength = transmission_data['Wavelength'].values * u.Unit(wavelength_unit)
 
-            return cls(wavelength, filter['Transmission'].values,
+            return cls(wavelength, transmission_data['Transmission'].values, detector_type,
                        interpolation_kind=interpolation_kind,
                        filter_id=filter_id, vega_fpath=vega_fpath)
 
-
-    def __init__(self, wavelength, transmission_lambda,
+    def __init__(self, wavelength, transmission_lambda, detector_type,
                  interpolation_kind='linear', filter_id=None, vega_fpath=None):
         if not hasattr(wavelength, 'unit'):
             raise ValueError('the wavelength needs to be a astropy quantity')
         self.wavelength = wavelength
         self.transmission_lambda = transmission_lambda
+        self.detector_type = detector_type
 
         self.interpolation_object = interpolate.interp1d(self.wavelength,
                                                          self.transmission_lambda,
@@ -145,7 +151,8 @@ class BaseFilterCurve(object):
     @utils.lazyproperty
     def lambda_pivot(self):
         """
-        Calculate the pivotal wavelength as defined in Bessell & Murphy 2012
+        Calculate the pivotal wavelength as defined as equation A16 in 
+        Bessell & Murphy 2012 (https://arxiv.org/abs/1112.2698)
 
         .. math::
 
@@ -153,9 +160,18 @@ class BaseFilterCurve(object):
             \\frac{\\int S(\\lambda)\\lambda d\\lambda}{\\int \\frac{S(\\lambda)}{\\lambda}}}\\\\
             <f_\\nu> = <f_\\lambda>\\frac{\\lambda_\\textrm{pivot}^2}{c}
         """
-
-        return np.sqrt((np.trapz(self.transmission_lambda * self.wavelength, self.wavelength)/
-                (np.trapz(self.transmission_lambda / self.wavelength, self.wavelength))))
+        if self.detector_type == DetectorType.PHOTON_COUNTER:
+            return np.sqrt(
+                np.trapz(self.transmission_lambda * self.wavelength, self.wavelength)/
+                np.trapz(self.transmission_lambda / self.wavelength, self.wavelength)
+                )
+        else:  # DetectorType.ENERGY_COUNTER
+            # substituting eq A9 in eq A16
+            return np.sqrt(
+                np.trapz(self.transmission_lambda, self.wavelength)/
+                np.trapz(self.transmission_lambda / (self.wavelength**2), self.wavelength)
+                )
+        
 
     @utils.lazyproperty
     def wavelength_start(self):
@@ -215,13 +231,19 @@ class BaseFilterCurve(object):
         Calculate the Integral :math:`\integral
         :return:
         """
-
-        return np.trapz(self.transmission_lambda * self.wavelength,
-                        self.wavelength)
+        if self.detector_type == DetectorType.PHOTON_COUNTER:
+            return np.trapz(self.transmission_lambda * self.wavelength,
+                            self.wavelength)
+        else:  # DetectorType.ENERGY_COUNTER
+            return np.trapz(self.transmission_lambda,
+                            self.wavelength)
 
     def calculate_weighted_average_wavelength(self):
         """
-        Calculate integral :math:`\\frac{\\int S(\\lambda) \\lambda d\\lambda}{\\int S(\\lambda) d\\lambda}`
+        Calculate integral defined as equation A14 in Bessell & Murphy 2012 
+        (https://arxiv.org/abs/1112.2698)
+        
+        :math:`\\frac{\\int S(\\lambda) \\lambda d\\lambda}{\\int S(\\lambda) d\\lambda}`
 
 
         Returns
@@ -229,9 +251,14 @@ class BaseFilterCurve(object):
 
 
         """
-
-        return (np.trapz(self.transmission_lambda * self.wavelength,
-                         self.wavelength) / self.calculate_wavelength_delta())
+        if self.detector_type == DetectorType.PHOTON_COUNTER:
+            return (self.calculate_wavelength_delta() /
+                    np.trapz(self.transmission_lambda, self.wavelength))
+        else:  # DetectorType.ENERGY_COUNTER
+            # substituting eq A9 in eq A14
+            return (self.calculate_wavelength_delta() /
+                    np.trapz(self.transmission_lambda / self.wavelength, self.wavelength))
+        
 
     def calculate_vega_magnitude(self, spectrum):
         __doc__ = calculate_vega_magnitude.__doc__

--- a/wsynphot/config.py
+++ b/wsynphot/config.py
@@ -73,17 +73,12 @@ def get_cache_updation_date():
     """
     config = get_configuration()
     cache_updation_date_text = config.get('cache_updation_date', None)
-    cache_dir = get_cache_dir()
 
     # Check whether date is present
     if cache_updation_date_text is None:
-        if os.listdir(cache_dir):
-            cache_updation_date = rectify_cache_updation_date(config,
-                'No date present, even when cache exists')
-        else:  # When cache is not downloaded/updated atleast once
-            cache_updation_date = None
+        cache_updation_date = None
 
-    else:
+    else: # Only when complete filter data was downloaded
         try:
             cache_updation_date = datetime.strptime(cache_updation_date_text, 
                 '%Y-%m-%d').date()
@@ -125,7 +120,7 @@ def rectify_cache_updation_date(config, error_log):
         '\n'.format(line_stars='*'*80, error_text=error_log))
 
     index_modification_timestamp = os.path.getmtime(os.path.join(get_cache_dir(),
-        'index.vot'))
+        'svo_index.vot'))
     cache_updation_date = datetime.fromtimestamp(index_modification_timestamp).date()
     config['cache_updation_date'] = str(cache_updation_date)
     yaml.dump(config, open(CONFIG_FPATH, 'w'), default_flow_style=False)

--- a/wsynphot/data/base.py
+++ b/wsynphot/data/base.py
@@ -14,7 +14,7 @@ ALPHA_LYR_FNAME = 'alpha_lyr_mod_002.fits'
 
 ALPHA_LYR_PATH = os.path.join(get_calibration_dir(), ALPHA_LYR_FNAME)
 
-ALPHA_LYR_MOD_URL= "ftp://ftp.stsci.edu/cdbs/calspec/{0}".format(
+ALPHA_LYR_MOD_URL = "https://archive.stsci.edu/hlsps/reference-atlases/cdbs/calspec/{0}".format(
     ALPHA_LYR_FNAME)
 
 

--- a/wsynphot/io/get_filter_data.py
+++ b/wsynphot/io/get_filter_data.py
@@ -52,14 +52,15 @@ def data_from_svo(query, error_msg='No data found for requested query'):
 
     Returns
     -------
-    astropy.io.votable.tree.Table object
-        Table element of the VOTable fetched from SVO (in response to query)
+    astropy.io.votable.tree.VOTableFile object
+        Entire VOTable fetched from SVO (in response to query)
     """
     response = session.get(SVO_MAIN_URL, params=query)
     response.raise_for_status()
     votable = io.BytesIO(response.content)
     try:
-        return parse_single_table(votable)
+        parse_single_table(votable)
+        return parse(votable) # to keep metadata stored as PARAMS
     except IndexError:
         # If no table element found in VOTable
         raise ValueError(error_msg)
@@ -80,8 +81,8 @@ def get_filter_index(wavelength_eff_min=0, wavelength_eff_max=FLOAT_MAX):
 
     Returns
     -------
-    astropy.io.votable.tree.Table object
-        Table element of the VOTable fetched from SVO (in response to query)
+    astropy.io.votable.tree.VOTableFile object
+        Entire VOTable fetched from SVO (in response to query)
     """
     wavelength_eff_min = u.Quantity(wavelength_eff_min, u.angstrom)
     wavelength_eff_max = u.Quantity(wavelength_eff_max, u.angstrom)
@@ -126,7 +127,7 @@ def get_filter_index_in_batches(n_batches=25):
         error_msg = f'No filter found for Wavelength Eff. range: {wavelength_eff_bins[i]:.2f} - {wavelength_eff_bins[i+1]:.2f}'
 
         try:
-            data_fetched = data_from_svo(query, error_msg).to_table()
+            data_fetched = data_from_svo(query, error_msg).get_first_table().to_table()
             if i == 0:
                 data = data_fetched
             else:
@@ -155,8 +156,8 @@ def get_transmission_data(filter_id):
 
     Returns
     -------
-    astropy.io.votable.tree.Table object
-        Table element of the VOTable fetched from SVO (in response to query)
+    astropy.io.votable.tree.VOTableFile object
+        Entire VOTable fetched from SVO (in response to query)
     """
     query = {'ID': filter_id}
     error_msg = 'No filter found for requested Filter ID'
@@ -176,8 +177,8 @@ def get_filter_list(facility, instrument=None):
 
     Returns
     -------
-    astropy.io.votable.tree.Table object
-        Table element of the VOTable fetched from SVO (in response to query)
+    astropy.io.votable.tree.VOTableFile object
+        Entire VOTable fetched from SVO (in response to query)
     """
     query = {'Facility': facility,
              'Instrument': instrument}


### PR DESCRIPTION
Fixes several problems:
- The source url of downloading calibration data from calspec was broken
- It was not possible for user to specify calibration file of their choice
-  The magnitude calculations assumed that all filters' detector type is photon counter, which gave wrong results when a filter's detector type is energy counter because the formula changes in latter case.
- It was not possible to use wsynphot without downloading all filters from SVO (i.e. 10k+ that takes ~1 hr). Also filter index in cache represented the filters at SVO, not the filters whose data files are actually downloaded, causing I/O bugs.

Each commit (in order of older to newer) solve these problems respectively.

Note: Don't squash when merging since this one PR solves multiple problems and each commit is atomic enough to represent each of them.